### PR TITLE
Fix/included relationships

### DIFF
--- a/src/Deserializer.js
+++ b/src/Deserializer.js
@@ -72,10 +72,10 @@ export default class Deserializer extends Normalizer {
       if (dataSet) {
         if (this.isCollection(data)) {
           let collection = _.compact(data.map(({_id, _type}) => dataSet.find((object) => object._id === _id)))
-          entity[relationship] = collection.map(object => this._hydrate(new Model(), object))
+          entity[relationship] = collection.map(object => this._hydrate(new Model(), { ...object, _included: included }))
         } else {
           let object = dataSet.find(({_id}) => _id === data._id)
-          entity[relationship] = this._hydrate(new Model(), object);
+          entity[relationship] = this._hydrate(new Model(), { ...object, _included: included });
         }
       }
     })

--- a/src/Model.js
+++ b/src/Model.js
@@ -3,7 +3,13 @@ import _ from 'lodash'
 export default class Model {
 
   static snakeCase(attribute) {
-    return _.snakeCase(attribute)
+    let underscore = ''
+
+    if (typeof attribute === 'string') {
+      underscore = (attribute.match(/^[_]/gm) || [])[0] || ''
+    }
+
+    return `${underscore}${_.snakeCase(attribute)}`
   }
 
   static isObject(data) {

--- a/tests/mocks/deserializedObject.js
+++ b/tests/mocks/deserializedObject.js
@@ -8,7 +8,27 @@ export default {
     id: 1,
     logo: '/assets/fallback/my-logo.png',
     config_links: {},
-    config_meta: {}
+    config_meta: {},
+    benefits: [
+      {
+        id: 1,
+        value_type: 'Percentage',
+        periodicity: 'Monthly',
+        extensible: true,
+        value: 80.00,
+        benefit_links: {},
+        benefit_meta: {},
+      },
+      {
+        id: 2,
+        value_type: 'Value',
+        periodicity: 'Monthly',
+        extensible: false,
+        value: 299.90,
+        benefit_links: {},
+        benefit_meta: {},
+      },
+    ]
   },
   addresses: [
     {

--- a/tests/model.test.js
+++ b/tests/model.test.js
@@ -10,6 +10,14 @@ describe('Normalizer', () => {
       expect(Model.snakeCase('UPPER_CASE_SNAKE_CASE')).toEqual('upper_case_snake_case')
     })
 
+    test('it must parse to snake_case starting with underscore', () => {
+      expect(Model.snakeCase('_camelCase')).toEqual('_camel_case')
+      expect(Model.snakeCase('_snake_case')).toEqual('_snake_case')
+      expect(Model.snakeCase('_kebab-case')).toEqual('_kebab_case')
+      expect(Model.snakeCase('_PascalCase')).toEqual('_pascal_case')
+      expect(Model.snakeCase('_UPPER_CASE_SNAKE_CASE')).toEqual('_upper_case_snake_case')
+    })
+
     test('it must check if its a object', () => {
       function Foo() {}
 


### PR DESCRIPTION
Fixes:
- Now the relationships within the included resources are parsed correctly.
- Attributes started with `_` are now supported. E.g: `_myAttribute, _my_attribute, _my-attribute`